### PR TITLE
fix chain id error

### DIFF
--- a/testnet-deploy.yml
+++ b/testnet-deploy.yml
@@ -17,32 +17,33 @@ services:
       - MNEMONIC=${MNEMONIC:?undefined MNEMONIC}
       - RPC_URL=${RPC_URL:?undefined RPC_URL}
       - NETWORK=${NETWORK:?undefined NETWORK}
+      - CHAIN_ID=${CHAIN_ID:?undefined CHAIN_ID}
 
   dapp-deployer:
     build:
       dockerfile_inline: |
-          # syntax=docker.io/docker/dockerfile:1.4
-          FROM gbbabarros/rollups-cli:1.0.1
-          RUN apk update && apk add jq
-          RUN <<EOF
-          echo '
-            #!/bin/sh
-            if [ ! -f /deployments/$NETWORK/rollups.json ]; then
-              echo "No authority defined"
-              exit 1
-            fi
-            echo "Deploying DApp on network \"$NETWORK\" using consensus address \"$(cat /deployments/$NETWORK/rollups.json | jq -r '.contracts.Authority.address')\"..."
-            cartesi-rollups create \
-                --rpc "$RPC_URL" \
-                --mnemonic "$MNEMONIC" \
-                --deploymentFile "/deployments/$NETWORK/rollups.json" \
-                --templateHashFile /var/opt/cartesi/machine-snapshots/image/hash \
-                --outputFile "/deployments/$NETWORK/dapp.json" \
-                --consensusAddress "$(cat /deployments/$NETWORK/rollups.json | jq -r '.contracts.Authority.address')"
-          ' > deploy.sh
-          EOF
-          ENTRYPOINT [ "sh"]
-          CMD ["deploy.sh" ]
+        # syntax=docker.io/docker/dockerfile:1.4
+        FROM gbbabarros/rollups-cli:1.0.1
+        RUN apk update && apk add jq
+        RUN <<EOF
+        echo '
+          #!/bin/sh
+          if [ ! -f /deployments/$NETWORK/rollups.json ]; then
+            echo "No authority defined"
+            exit 1
+          fi
+          echo "Deploying DApp on network \"$NETWORK\" using consensus address \"$(cat /deployments/$NETWORK/rollups.json | jq -r '.contracts.Authority.address')\"..."
+          cartesi-rollups create \
+              --rpc "$RPC_URL" \
+              --mnemonic "$MNEMONIC" \
+              --deploymentFile "/deployments/$NETWORK/rollups.json" \
+              --templateHashFile /var/opt/cartesi/machine-snapshots/image/hash \
+              --outputFile "/deployments/$NETWORK/dapp.json" \
+              --consensusAddress "$(cat /deployments/$NETWORK/rollups.json | jq -r '.contracts.Authority.address')"
+        ' > deploy.sh
+        EOF
+        ENTRYPOINT [ "sh"]
+        CMD ["deploy.sh" ]
 
     volumes:
       - ./.sunodo:/var/opt/cartesi/machine-snapshots:ro


### PR DESCRIPTION
When deploying to custom chains not on wagmi we face an error due to the chain id not being defined.
We can fix this by simply adding this to the yaml file.
